### PR TITLE
Implementing PlayerPosition Packet

### DIFF
--- a/examples/wows_parser/player.py
+++ b/examples/wows_parser/player.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 import os
 
-from replay_unpack.clients.wot.network.packets import (
+from replay_unpack.clients.wows.network.packets import (
     Position
 )
 from replay_unpack.clients.wows.player import ReplayPlayer as WoWSReplayPlayer

--- a/replay_unpack/clients/wows/network/packets/PlayerPosition.py
+++ b/replay_unpack/clients/wows/network/packets/PlayerPosition.py
@@ -6,25 +6,24 @@ from replay_unpack.core import PrettyPrintObjectMixin
 from replay_unpack.core.network.types import Vector3
 
 
-class Position(PrettyPrintObjectMixin):
+class PlayerPosition(PrettyPrintObjectMixin):
     __slots__ = (
-        'entityId',
-        'vehicleId',
+        'entityId1',
+        'entityId2',
         'position',
-        'positionError',
         'yaw',
         'pitch',
-        'roll',
-        'is_error'
+        'roll'
     )
-
+    
     def __init__(self, stream):
         # type: (BytesIO) -> ()
-        self.entityId, = struct.unpack('i', stream.read(4))
-        self.vehicleId, = struct.unpack('i', stream.read(4))
+
+        self.entityId1 = struct.unpack('i', stream.read(4))
+        self.entityId2 = struct.unpack('i', stream.read(4))
+
         self.position = Vector3(stream)
-        self.positionError = Vector3(stream)
         self.yaw, = struct.unpack('f', stream.read(4))
         self.pitch, = struct.unpack('f', stream.read(4))
         self.roll, = struct.unpack('f', stream.read(4))
-        self.is_error, = struct.unpack('b', stream.read(1))
+        

--- a/replay_unpack/clients/wows/network/packets/PlayerPosition.py
+++ b/replay_unpack/clients/wows/network/packets/PlayerPosition.py
@@ -19,8 +19,8 @@ class PlayerPosition(PrettyPrintObjectMixin):
     def __init__(self, stream):
         # type: (BytesIO) -> ()
 
-        self.entityId1 = struct.unpack('i', stream.read(4))
-        self.entityId2 = struct.unpack('i', stream.read(4))
+        self.entityId1, = struct.unpack('i', stream.read(4))
+        self.entityId2, = struct.unpack('i', stream.read(4))
 
         self.position = Vector3(stream)
         self.yaw, = struct.unpack('f', stream.read(4))

--- a/replay_unpack/clients/wows/network/packets/__init__.py
+++ b/replay_unpack/clients/wows/network/packets/__init__.py
@@ -7,11 +7,12 @@ from replay_unpack.core.packets import (
     EntityMethod,
     NestedProperty,
     BasePlayerCreate,
-    Position
+    Position,
 )
 from .CellPlayerCreate import CellPlayerCreate
 from .EntityCreate import EntityCreate
 from .Map import Map
+from .PlayerPosition import PlayerPosition
 
 PACKETS_MAPPING = {
     0x0: BasePlayerCreate,
@@ -25,7 +26,8 @@ PACKETS_MAPPING = {
     0x8: EntityMethod,
     0x27: Map,
     0x22: NestedProperty,
-    0x0a: Position
+    0x0a: Position,
+    0x2b: PlayerPosition
 }
 
 __all__ = [
@@ -40,6 +42,7 @@ __all__ = [
     'EntityProperty',
     'CellPlayerCreate',
     'NestedProperty',
+    'PlayerPosition',
 
     'PACKETS_MAPPING'
 ]

--- a/replay_unpack/clients/wows/player.py
+++ b/replay_unpack/clients/wows/player.py
@@ -118,17 +118,17 @@ class ReplayPlayer(ControlledPlayerBase):
                     # where the position of entity 1 is set by wherever entity 2
                     # is, rather than by the position field.
                     # e.g. Assigning the Avatar the position of the Vehicle
-                    master_entity = self._battle_controller.entities[packet.entityId2[0]]
-                    slave_entity = self._battle_controller.entities[packet.entityId1[0]]
+                    master_entity = self._battle_controller.entities[packet.entityId2]
+                    slave_entity = self._battle_controller.entities[packet.entityId1]
                     
                     slave_entity.position = master_entity.position
                     slave_entity.yaw = master_entity.yaw
                     slave_entity.pitch = master_entity.pitch
                     slave_entity.roll = master_entity.roll
                     
-                elif packet.entityId1 != (0,) and packet.entityId2 == (0,):
+                elif packet.entityId1 != 0 and packet.entityId2 == 0:
                     # This is a regular update for entity 1, without entity 2
-                    e = self._battle_controller.entities[packet.entityId1[0]]
+                    e = self._battle_controller.entities[packet.entityId1]
 
                     e.position = packet.position
                     e.yaw = packet.yaw


### PR DESCRIPTION
Added support for the PlayerPosition packet for World of Warships.  This change parses and sets the position and yaw/pitch/roll values on a PlayerPosition packet, and sets those fields on the corresponding entity in the battle controller.  If a second entity ID is provided instead of a full position, then the logic sets the primary entity's position equal to the "linked" entity's position (e.g. set the Avatar's position equal to the position of its linked Vehicle).
This change also includes a minor update to the WoWs example to import the WoWs network packets instead of the WoT ones.  Closes #14 