### PR TITLE
change avatar_id to avatar.id to make achievements compatible

### DIFF
--- a/replay_unpack/clients/wows/versions/0_11_5/battle_controller.py
+++ b/replay_unpack/clients/wows/versions/0_11_5/battle_controller.py
@@ -147,8 +147,8 @@ class BattleController(IBattleController):
         self._ribbons[avatar.id][ribbon_id] += 1
 
     def onAchievementEarned(self, avatar, avatar_id, achievement_id):
-        self._achievements.setdefault(avatar_id, {}).setdefault(achievement_id, 0)
-        self._achievements[avatar_id][achievement_id] += 1
+        self._achievements.setdefault(avatar.id, {}).setdefault(achievement_id, 0)
+        self._achievements[avatar.id][achievement_id] += 1
 
     def receiveVehicleDeath(self, avatar, killedVehicleId, fraggerVehicleId, typeDeath):
         self._death_map.append((killedVehicleId, fraggerVehicleId, typeDeath))


### PR DESCRIPTION
Hi, this change makes more compatible the achievements, it makes the achievements have the same key as the ribbons.
I hope you found it useful.

![image](https://user-images.githubusercontent.com/45885904/174889094-d08c3720-77a9-494a-b45d-4948977df49a.png)
![image](https://user-images.githubusercontent.com/45885904/174889116-1eedbd5f-bcf2-42c7-b04c-6b6ad223b76a.png)
