### PR TITLE
Added Version packet and a way to subscribe to nested property changes.

### DIFF
--- a/replay_unpack/clients/wows/network/packets/__init__.py
+++ b/replay_unpack/clients/wows/network/packets/__init__.py
@@ -8,6 +8,7 @@ from replay_unpack.core.packets import (
     NestedProperty,
     BasePlayerCreate,
     Position,
+    Version
 )
 from .CellPlayerCreate import CellPlayerCreate
 from .EntityCreate import EntityCreate
@@ -27,6 +28,7 @@ PACKETS_MAPPING = {
     0x27: Map,
     0x22: NestedProperty,
     0x0a: Position,
+    0x16: Version,
     0x2b: PlayerPosition
 }
 
@@ -43,6 +45,6 @@ __all__ = [
     'CellPlayerCreate',
     'NestedProperty',
     'PlayerPosition',
-
+    'Version',
     'PACKETS_MAPPING'
 ]

--- a/replay_unpack/clients/wows/player.py
+++ b/replay_unpack/clients/wows/player.py
@@ -20,6 +20,7 @@ from .network.packets import (
     EntityEnter,
     EntityLeave,
     PlayerPosition,
+    Version,
     PACKETS_MAPPING
 )
 
@@ -42,6 +43,8 @@ class ReplayPlayer(ControlledPlayerBase):
         return PACKETS_MAPPING
 
     def _process_packet(self, packet):
+        if isinstance(packet, Version):
+            logging.debug('Game version: %s', packet.version)
 
         if isinstance(packet, Map):
             logging.debug('Welcome to map %s: %s', packet.name, packet.arenaId)

--- a/replay_unpack/clients/wows/versions/0_11_6/battle_controller.py
+++ b/replay_unpack/clients/wows/versions/0_11_6/battle_controller.py
@@ -43,6 +43,11 @@ class BattleController(IBattleController):
         Entity.subscribe_method_call('Avatar', 'onNewPlayerSpawnedInBattle', self.onNewPlayerSpawnedInBattle)
 
         Entity.subscribe_method_call('Vehicle', 'receiveDamagesOnShip', self.g_receiveDamagesOnShip)
+        Entity.subscribe_nested_property_change('BattleLogic', 'state.controlPoints', self.controlPoints)
+
+    def controlPoints(self, entity, control_points):
+        # print(control_points)
+        pass
 
     def onSetConsumable(self, vehicle, blob):
         print(pickle.loads(blob))

--- a/replay_unpack/core/packets/Version.py
+++ b/replay_unpack/core/packets/Version.py
@@ -1,0 +1,7 @@
+import struct
+
+
+class Version:
+    def __init__(self, stream):
+        self._size, = struct.unpack('i', stream.read(4))
+        self.version = stream.read(self._size).decode('utf8')

--- a/replay_unpack/core/packets/__init__.py
+++ b/replay_unpack/core/packets/__init__.py
@@ -12,6 +12,7 @@ from .EntityProperty import EntityProperty
 from .Map import Map
 from .NestedProperty import NestedProperty
 from .Position import Position
+from .Version import Version
 
 __all__ = [
     'EntityMethod',
@@ -26,4 +27,5 @@ __all__ = [
     'EntityProperty',
     'CellPlayerCreate',
     'NestedProperty',
+    'Version'
 ]


### PR DESCRIPTION
Subscribing to nested property can be done with:
`Entity.subscribe_nested_property_change(Entity_name, property_path, func)`
`Entity.subscribe_nested_property_change('BattleLogic', 'state.controlPoints', lambda *arg, **kwargs: print(arg, kwargs))`
`{'position': [0.0, -0.0001983642578125], 'radius': 151.0, 'innerRadius': 0.0,....`

This will pass the property's value to the function.
